### PR TITLE
Do not check flag parsing

### DIFF
--- a/klog.go
+++ b/klog.go
@@ -725,10 +725,7 @@ func (l *loggingT) output(s severity, buf *buffer, file string, line int, alsoTo
 		}
 	}
 	data := buf.Bytes()
-	if !flag.Parsed() {
-		os.Stderr.Write([]byte("ERROR: logging before flag.Parse: "))
-		os.Stderr.Write(data)
-	} else if l.toStderr {
+	if l.toStderr {
 		os.Stderr.Write(data)
 	} else {
 		if alsoToStderr || l.alsoToStderr || s >= l.stderrThreshold.get() {


### PR DESCRIPTION
Undo the change from:
https://github.com/golang/glog/commit/65d674618f712aa808a7d0104131b9206fc3d5ad

As this change is NOT present in the vendored glog in k/k:
https://github.com/golang/glog/compare/44145f04b68cf362d9c4df2182967c2275eaefed...HEAD

Also, it just breaks stuff (see comments in url above)

Change-Id: I90774b10929064c241d2a41c2b30d8bb9be833ca